### PR TITLE
hamcrest v2.2

### DIFF
--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -62,6 +62,12 @@
       <artifactId>junit</artifactId>
       <version>4.10</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,12 @@
       <artifactId>junit</artifactId>
       <version>4.11</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -32,14 +32,8 @@
     <dependencies>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>1.3</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>1.3</version>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
Upgrade to hamcrest v2.2 from v1.3

NOTE: getting build error on master and this branch due to.
`commons-chain/base/src/main/java/org/apache/commons/chain2/impl/ContextBase.java:[279,24] keySet() in org.apache.commons.chain2.impl.ContextBase cannot override keySet() in java.util.concurrent.ConcurrentHashMap
  return type java.util.Set<java.lang.String> is not compatible with java.util.concurrent.ConcurrentHashMap.KeySetView<java.lang.String,java.lang.Object>`