### PR TITLE
Extending filter and chain base to support rollback on exception 

### DIFF
--- a/api/src/main/java/org/apache/commons/chain2/Filter.java
+++ b/api/src/main/java/org/apache/commons/chain2/Filter.java
@@ -66,4 +66,6 @@ public interface Filter<K, V, C extends Map<K, V>> extends Command<K, V, C> {
      */
    boolean postprocess(C context, Exception exception);
 
+   void undo(C context, Exception exception);
+
 }

--- a/base/src/main/java/org/apache/commons/chain2/base/LookupCommand.java
+++ b/base/src/main/java/org/apache/commons/chain2/base/LookupCommand.java
@@ -309,6 +309,15 @@ public class LookupCommand<K, V, C extends Map<K, V>> implements Filter<K, V, C>
         return false;
     }
 
+    public void undo(C context, Exception exception) {
+        Command<K, V, C> command = getCommand(context);
+        if (command != null) {
+            if (command instanceof Filter) {
+                ((Filter<K, V, C>) command).undo(context, exception);
+            }
+        }
+    }
+
     // --------------------------------------------------------- Private Methods
 
     /**

--- a/base/src/main/java/org/apache/commons/chain2/impl/ChainBase.java
+++ b/base/src/main/java/org/apache/commons/chain2/impl/ChainBase.java
@@ -16,7 +16,6 @@
  */
 package org.apache.commons.chain2.impl;
 
-import jdk.vm.ci.meta.ExceptionHandler;
 import org.apache.commons.chain2.Chain;
 import org.apache.commons.chain2.Command;
 import org.apache.commons.chain2.Context;

--- a/base/src/main/java/org/apache/commons/chain2/impl/ContextBase.java
+++ b/base/src/main/java/org/apache/commons/chain2/impl/ContextBase.java
@@ -275,7 +275,7 @@ public class ContextBase extends ContextMap<String, Object> {
      * @return The set of keys for objects in this Context.
      */
     @Override
-    public Set<String> keySet() {
+    public KeySetView<String, Object> keySet() {
         return super.keySet();
     }
 

--- a/base/src/test/java/org/apache/commons/chain2/impl/ChainBaseRollbackTestCase.java
+++ b/base/src/test/java/org/apache/commons/chain2/impl/ChainBaseRollbackTestCase.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.chain2.impl;
+
+import org.apache.commons.chain2.Chain;
+import org.apache.commons.chain2.ChainException;
+import org.apache.commons.chain2.Context;
+import org.apache.commons.chain2.testutils.ExceptionRollbackFilter;
+import org.apache.commons.chain2.testutils.NonDelegatingCommand;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.apache.commons.chain2.testutils.HasLog.hasLog;
+import static org.junit.Assert.assertThat;
+
+public class ChainBaseRollbackTestCase {
+
+    /**
+     * The {@link Chain} instance under test.
+     */
+    protected Chain<String, Object, Context<String, Object>> chain = null;
+
+
+    /**
+     * The {@link Context} instance on which to execute the chain.
+     */
+    protected Context<String, Object> context = null;
+
+
+    // -------------------------------------------------- Overall Test Methods
+
+
+    /**
+     * Set up instance variables required by this test case.
+     */
+    @Before
+    public void setUp() {
+        chain = new ChainBase<String, Object, Context<String, Object>>();
+        context = new ContextBase();
+    }
+
+    /**
+     * Tear down instance variables required by this test case.
+     */
+    @After
+    public void tearDown() {
+        chain = null;
+        context = null;
+    }
+
+
+    @Test(expected = ChainException.class)
+    public void nullReturningCommandForcesException() {
+        chain.addCommand(new ExceptionRollbackFilter("exceptionRollbackFilter"));
+        chain.addCommand(new NonDelegatingCommand("non delegating command"));
+        chain.execute(context);
+
+        assertThat(context, hasLog("2"));
+    }
+}

--- a/test-utils/src/main/java/org/apache/commons/chain2/testutils/ExceptionFilter.java
+++ b/test-utils/src/main/java/org/apache/commons/chain2/testutils/ExceptionFilter.java
@@ -66,5 +66,9 @@ public class ExceptionFilter
         return (false);
     }
 
+    // Undo operation for this Filter
+    public void undo(Context<String, Object> context, Exception exception) {
+        log(context, id2);
+    }
 
 }

--- a/test-utils/src/main/java/org/apache/commons/chain2/testutils/ExceptionRollbackFilter.java
+++ b/test-utils/src/main/java/org/apache/commons/chain2/testutils/ExceptionRollbackFilter.java
@@ -16,58 +16,35 @@
  */
 package org.apache.commons.chain2.testutils;
 
-
 import org.apache.commons.chain2.Context;
 import org.apache.commons.chain2.Filter;
+import org.apache.commons.chain2.Processing;
 
+public class ExceptionRollbackFilter implements Filter<String, Object, Context<String, Object>> {
 
-/**
- * <p>Implementation of {@link Filter} that logs its identifier and
- * and throws an Exception.</p>
- *
- * @version $Id$
- */
-public class ExceptionFilter
-    extends ExceptionCommand implements Filter<String, Object, Context<String, Object>> {
-
-
-    // ------------------------------------------------------------- Constructor
-
-
-    public ExceptionFilter() {
-        this("", "");
-    }
-
+    protected String id = null;
 
     // Construct an instance that will log the specified identifier
-    public ExceptionFilter(String id1, String id2) {
-        super(id1);
-        this.id2 = id2;
+    public ExceptionRollbackFilter(String id) {
+        this.id = id;
     }
-
-
-    // -------------------------------------------------------------- Properties
-
-    protected String id2 = null;
-    public String getId2() {
-        return (this.id2);
-    }
-    public void setId2(String id2) {
-        this.id2 = id2;
-    }
-
-
-    // --------------------------------------------------------- Command Methods
-
 
     // Postprocess command for this Filter
     public boolean postprocess(Context<String, Object> context, Exception exception) {
-        log(context, id2);
         return (false);
     }
 
     // Undo operation for this Filter
     public void undo(Context<String, Object> context, Exception exception) {
+        log(context, id);
     }
 
+    @Override
+    public Processing execute(Context<String, Object> context) {
+        throw new ArithmeticException(this.id);
+    }
+
+    protected void log(Context<String, Object> context, String id) {
+        context.put("log", id);
+    }
 }

--- a/test-utils/src/main/java/org/apache/commons/chain2/testutils/NonDelegatingFilter.java
+++ b/test-utils/src/main/java/org/apache/commons/chain2/testutils/NonDelegatingFilter.java
@@ -79,5 +79,7 @@ public class NonDelegatingFilter
         return (false);
     }
 
+    public void undo(Context<String, Object> context, Exception exception) {
+    }
 
 }


### PR DESCRIPTION
In the current implementation of Chain base and filter command, there is no support for rollback/undo operations when there is an exception thrown in the chain. 
This PP 
1. extends the Filter by adding an undo method
2. extends ChainBase to execute the undo method on the commands in the chain (from the point of exception to top of the chain)